### PR TITLE
Removed call to open() from example

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ frisby.create(...)
     .get('/foobar')
     .reply(200))
   .networkOn()
-  .open()
   .expectJSON(...)
   .toss()
 ```


### PR DESCRIPTION
This pull request should resolve #3 by updating the relevant example in the Readme. 😉 